### PR TITLE
Only process variables from env file, instead of every line in the file.

### DIFF
--- a/dotenv.php
+++ b/dotenv.php
@@ -41,6 +41,7 @@ class DotenvPlugin extends Plugin
             $message = 'DotEnv: ' . $exception->getMessage();
 
             $this->grav['debugger']->addMessage($message);
+            $this->grav['log']->warning($message);
 
             if ($this->isAdmin()) {
                 $this->grav['admin']->setMessage($message, 'warning');
@@ -53,7 +54,8 @@ class DotenvPlugin extends Plugin
      */
     protected function init()
     {
-        foreach ($this->dotenv->load() as $setting) {
+        $this->dotenv->load();
+        foreach ($this->dotenv->getEnvironmentVariableNames() as $setting) {
             $settingData = $this->getSetting($setting);
 
             $this->grav['config']->join($settingData['grav_pointer'], [
@@ -69,12 +71,8 @@ class DotenvPlugin extends Plugin
      *
      * @return array
      */
-    protected function getSetting($setting)
+    protected function getSetting($name)
     {
-        if (strpos($setting, '=') !== false) {
-            list($name, $value) = array_map('trim', explode('=', $setting, 2));
-        }
-
         // Name is not dot notated, it should be.
         if (strpos($name, '.') === false) {
             return;
@@ -86,7 +84,7 @@ class DotenvPlugin extends Plugin
             'grav_pointer'  => implode('.', array_slice($parts, 0, -1)),
             'env_name'      => implode('.', $parts),
             'key'           => end($parts),
-            'value'         => $value,
+            'value'         => getenv($name),
         ];
     }
 }


### PR DESCRIPTION
`$dotenv->load()` returns every line from the env file including comments. Use `$dotenv->getEnvironmentVariableNames()` so we only process the variables. 

Also, log a warning on exceptions, so errors can be seen if not using the debugger or admin.